### PR TITLE
Use latest openDAQ SDK 3.10

### DIFF
--- a/recipes-opendaq/opendaq-sdk/opendaq-sdk_git.bb
+++ b/recipes-opendaq/opendaq-sdk/opendaq-sdk_git.bb
@@ -24,7 +24,7 @@ LIC_FILES_CHKSUM += "file://LICENSE;md5=98b4c298fafe3a9dc30f957028ce3224"
 
 SRCREV_FORMAT = "opendaq-sdk_tmsspec"
 # commit from release/3.10
-SRCREV_opendaq-sdk = "96dce1876a9d748796f5c85b63dc633b6c8481c8"
+SRCREV_opendaq-sdk = "45a66d45bdf5f56130f5c81195cae6c70a3ec2d3"
 SRCREV_tmsspec = "9f7306e702e3cf698ff7fcabe421ef4c9b77139d"
 SRCREV_daqhbkspec = "cd7e6033eb74b7f1725edbf2035f0e4c6fa2cc96"
 


### PR DESCRIPTION
use latest openDAQ SDK 3.10

This has a breaking change: "Move all uses of internal `sync` mutex to protected functions."